### PR TITLE
Correction unserialization debug toolbar

### DIFF
--- a/src/DataCollector/ClientRequest.php
+++ b/src/DataCollector/ClientRequest.php
@@ -1,15 +1,20 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Yproximite\Bundle\InfluxDbPresetBundle\DataCollector;
 
+use Yproximite\Bundle\InfluxDbPresetBundle\Connection\Connection;
+use Yproximite\Bundle\InfluxDbPresetBundle\Connection\ConnectionInterface;
+use Yproximite\Bundle\InfluxDbPresetBundle\Point\PointPreset;
+use Yproximite\Bundle\InfluxDbPresetBundle\Profile\Profile;
 use Yproximite\Bundle\InfluxDbPresetBundle\Profile\ProfileInterface;
 use Yproximite\Bundle\InfluxDbPresetBundle\Point\PointPresetInterface;
 
 /**
  * Class ClientRequest
  */
-class ClientRequest
+class ClientRequest implements \Serializable
 {
     /**
      * @var ProfileInterface
@@ -61,5 +66,81 @@ class ClientRequest
     public function getDateTime(): \DateTimeInterface
     {
         return $this->dateTime;
+    }
+
+    public function serialize()
+    {
+        return serialize([
+            $this->value,
+            $this->dateTime,
+            $this->profile->getName(),
+            array_map(function (ConnectionInterface $connection) {
+                return $this->serializeConnection($connection);
+            }, $this->profile->getConnections()),
+            array_map(function (PointPreset $pointPreset) {
+                return $this->serializePointPreset($pointPreset);
+            }, $this->profile->getPointPresets()),
+            $this->serializePointPreset($this->pointPreset),
+        ]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->value, $this->dateTime, $profileName, $profileConnections, $profilePointPresets, $pointPreset) = unserialize($serialized);
+
+        $this->pointPreset = $this->unserializePointPreset($pointPreset);
+
+        $this->profile = new Profile();
+        $this->profile->setName($profileName);
+
+        foreach ($profileConnections as $connection) {
+            $this->profile->addConnection($this->unserializeConnection($connection));
+        }
+
+        foreach ($profilePointPresets as $pointPreset) {
+            $this->profile->addPointPreset($this->unserializePointPreset($pointPreset));
+        }
+    }
+
+    protected function serializePointPreset(PointPresetInterface $pointPreset): array
+    {
+        return [
+            $pointPreset->getName(),
+            $pointPreset->getFields(),
+            $pointPreset->getMeasurement(),
+            $pointPreset->getTags(),
+        ];
+    }
+
+    protected function unserializePointPreset(array $pointPreset): PointPresetInterface
+    {
+        $newPointPreset = new PointPreset();
+        $newPointPreset->setName($pointPreset[0])
+            ->setFields($pointPreset[1])
+            ->setMeasurement($pointPreset[2])
+            ->setTags($pointPreset[3])
+        ;
+
+        return $newPointPreset;
+    }
+
+    protected function serializeConnection(ConnectionInterface $connection): array
+    {
+        return [
+            $connection->getName(),
+            $connection->getProtocol(),
+            $connection->isDeferred(),
+        ];
+    }
+
+    protected function unserializeConnection(array $connection): ConnectionInterface
+    {
+        $newConnection = new Connection();
+        $newConnection->setName($connection[0])
+            ->setProtocol($connection[1])
+            ->setDeferred($connection[2])
+        ;
+
+        return $newConnection;
     }
 }

--- a/src/Profile/Profile.php
+++ b/src/Profile/Profile.php
@@ -57,6 +57,11 @@ class Profile implements ProfileInterface
         throw new PresetNotFoundException(sprintf('Could not find the preset "%s".', $presetName));
     }
 
+    public function getPointPresets(): array
+    {
+        return $this->pointPresets;
+    }
+
     public function addConnection(ConnectionInterface $connection): ProfileInterface
     {
         $this->connections[] = $connection;

--- a/src/Profile/ProfileInterface.php
+++ b/src/Profile/ProfileInterface.php
@@ -19,6 +19,8 @@ interface ProfileInterface
 
     public function getPointPresetByName(string $presetName): PointPresetInterface;
 
+    public function getPointPresets(): array;
+
     public function addConnection(ConnectionInterface $connection): self;
 
     /**


### PR DESCRIPTION
La debug toolbar ne s'affichait plus lorsque que l'on avait plus d'un flux envoyé. Cela venait de la désérialisation des données. Lorsque PHP sérialise les données il peut passer des références. Lorsque que se sont des variables pas de soucis mais avec les objets la désérialisation échoue.
J'ai donc implémenté Serialize et modifié les données pour envoyer des variables et non plus des objets à serialiser.